### PR TITLE
feat!: include top-level options with `"help"` result

### DIFF
--- a/.changeset/silly-rocks-smile.md
+++ b/.changeset/silly-rocks-smile.md
@@ -1,0 +1,5 @@
+---
+'ordana': minor
+---
+
+Change the signature of generateHelpMessage for easier usage.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ console.log(result)
 const input2 = ['dev', '--help']
 const result2 = parse(input2, options) // options is the same as above
 if (result2.type === 'help') {
-  const helpMessage = generateHelpMessage(options, result2.targetSubcommand)
+  const helpMessage = generateHelpMessage(result2)
   console.log(helpMessage)
   /*
     foo dev - my subcommand

--- a/packages/ordana/src/help.test.ts
+++ b/packages/ordana/src/help.test.ts
@@ -44,28 +44,40 @@ describe('generateHelpMessage', () => {
   } as const satisfies TopLevelOptions
 
   test('top-level command', async () => {
-    const actual = generateHelpMessage(opts, undefined)
+    const actual = generateHelpMessage({
+      topLevelOpts: opts,
+      targetSubcommand: undefined
+    })
     await expect(stripVTControlCharacters(actual)).toMatchFileSnapshot(
       './snapshot/foo-top-level.help.txt'
     )
   })
 
   test('top-level command with default subcommand', async () => {
-    const actual = generateHelpMessage(opts2, undefined)
+    const actual = generateHelpMessage({
+      topLevelOpts: opts2,
+      targetSubcommand: undefined
+    })
     await expect(stripVTControlCharacters(actual)).toMatchFileSnapshot(
       './snapshot/foo2-top-level.help.txt'
     )
   })
 
   test('subcommand', async () => {
-    const actual = generateHelpMessage(opts, 'bar')
+    const actual = generateHelpMessage({
+      topLevelOpts: opts,
+      targetSubcommand: 'bar'
+    })
     await expect(stripVTControlCharacters(actual)).toMatchFileSnapshot(
       './snapshot/foo-bar.help.txt'
     )
   })
 
   test('subcommand with alias', async () => {
-    const actual = generateHelpMessage(opts2, 'baz')
+    const actual = generateHelpMessage({
+      topLevelOpts: opts2,
+      targetSubcommand: 'baz'
+    })
     await expect(stripVTControlCharacters(actual)).toMatchFileSnapshot(
       './snapshot/foo2-baz.help.txt'
     )

--- a/packages/ordana/src/help.test.ts
+++ b/packages/ordana/src/help.test.ts
@@ -45,7 +45,7 @@ describe('generateHelpMessage', () => {
 
   test('top-level command', async () => {
     const actual = generateHelpMessage({
-      topLevelOpts: opts,
+      topLevelOptions: opts,
       targetSubcommand: undefined
     })
     await expect(stripVTControlCharacters(actual)).toMatchFileSnapshot(
@@ -55,7 +55,7 @@ describe('generateHelpMessage', () => {
 
   test('top-level command with default subcommand', async () => {
     const actual = generateHelpMessage({
-      topLevelOpts: opts2,
+      topLevelOptions: opts2,
       targetSubcommand: undefined
     })
     await expect(stripVTControlCharacters(actual)).toMatchFileSnapshot(
@@ -65,7 +65,7 @@ describe('generateHelpMessage', () => {
 
   test('subcommand', async () => {
     const actual = generateHelpMessage({
-      topLevelOpts: opts,
+      topLevelOptions: opts,
       targetSubcommand: 'bar'
     })
     await expect(stripVTControlCharacters(actual)).toMatchFileSnapshot(
@@ -75,7 +75,7 @@ describe('generateHelpMessage', () => {
 
   test('subcommand with alias', async () => {
     const actual = generateHelpMessage({
-      topLevelOpts: opts2,
+      topLevelOptions: opts2,
       targetSubcommand: 'baz'
     })
     await expect(stripVTControlCharacters(actual)).toMatchFileSnapshot(

--- a/packages/ordana/src/help.ts
+++ b/packages/ordana/src/help.ts
@@ -1,7 +1,4 @@
-import type {
-  SubCommandOptions,
-  TopLevelOptions
-} from './types.ts'
+import type { SubCommandOptions, TopLevelOptions } from './types.ts'
 import {
   getAliasList,
   getCommand,
@@ -17,10 +14,10 @@ import * as c from 'picocolors'
  * @param result The result of the parsed command.
  */
 export function generateHelpMessage({
-  topLevelOpts,
+  topLevelOptions: topLevelOpts,
   targetSubcommand
 }: {
-  topLevelOpts: TopLevelOptions
+  topLevelOptions: TopLevelOptions
   targetSubcommand: string | undefined
 }): string {
   const subcommand = targetSubcommand

--- a/packages/ordana/src/help.ts
+++ b/packages/ordana/src/help.ts
@@ -1,4 +1,7 @@
-import type { SubCommandOptions, TopLevelOptions } from './types.ts'
+import type {
+  SubCommandOptions,
+  TopLevelOptions
+} from './types.ts'
 import {
   getAliasList,
   getCommand,
@@ -11,12 +14,15 @@ import * as c from 'picocolors'
 /**
  * Generate help message
  *
- * @param targetSubcommand The subcommand to generate help message for. If `undefined`, generate help message for the top level command.
+ * @param result The result of the parsed command.
  */
-export function generateHelpMessage(
-  topLevelOpts: TopLevelOptions,
+export function generateHelpMessage({
+  topLevelOpts,
+  targetSubcommand
+}: {
+  topLevelOpts: TopLevelOptions
   targetSubcommand: string | undefined
-): string {
+}): string {
   const subcommand = targetSubcommand
     ? topLevelOpts.subcommands[targetSubcommand]
     : undefined

--- a/packages/ordana/src/parse.test.ts
+++ b/packages/ordana/src/parse.test.ts
@@ -398,18 +398,22 @@ describe('global arguments', () => {
 
 describe('--help works', () => {
   test('without subcommand', () => {
-    const actual = parse(['--help'], { subcommands: {} })
+    const options = { subcommands: {} }
+    const actual = parse(['--help'], options)
     expect(actual).toStrictEqual({
       type: 'help',
-      targetSubcommand: undefined
+      targetSubcommand: undefined,
+      topLevelOpts: options
     })
   })
 
   test('with subcommand', () => {
-    const actual = parse(['dev', '--help'], { subcommands: { dev: {} } })
+    const options = { subcommands: { dev: {} } }
+    const actual = parse(['dev', '--help'], options)
     expect(actual).toStrictEqual({
       type: 'help',
-      targetSubcommand: 'dev'
+      targetSubcommand: 'dev',
+      topLevelOpts: options
     })
   })
 

--- a/packages/ordana/src/parse.test.ts
+++ b/packages/ordana/src/parse.test.ts
@@ -403,7 +403,7 @@ describe('--help works', () => {
     expect(actual).toStrictEqual({
       type: 'help',
       targetSubcommand: undefined,
-      topLevelOpts: options
+      topLevelOptions: options
     })
   })
 
@@ -413,7 +413,7 @@ describe('--help works', () => {
     expect(actual).toStrictEqual({
       type: 'help',
       targetSubcommand: 'dev',
-      topLevelOpts: options
+      topLevelOptions: options
     })
   })
 

--- a/packages/ordana/src/parse.ts
+++ b/packages/ordana/src/parse.ts
@@ -25,7 +25,7 @@ export function parse<T extends TopLevelOptions>(
 ): ParsedResults<T> {
   const maybeSubcommand = input[0]
   if (maybeSubcommand === HELP_FLAG) {
-    return { type: 'help', targetSubcommand: undefined }
+    return { type: 'help', targetSubcommand: undefined, topLevelOpts }
   }
 
   const [subcommandName, subcommand, defaultSubcommandUsed] = selectSubcommand(
@@ -45,7 +45,7 @@ export function parse<T extends TopLevelOptions>(
 
   const args = !defaultSubcommandUsed ? input.slice(1) : input
   if (args[0] === HELP_FLAG) {
-    return { type: 'help', targetSubcommand: subcommandName }
+    return { type: 'help', targetSubcommand: subcommandName, topLevelOpts }
   }
 
   const mergedArguments = {

--- a/packages/ordana/src/parse.ts
+++ b/packages/ordana/src/parse.ts
@@ -25,7 +25,11 @@ export function parse<T extends TopLevelOptions>(
 ): ParsedResults<T> {
   const maybeSubcommand = input[0]
   if (maybeSubcommand === HELP_FLAG) {
-    return { type: 'help', targetSubcommand: undefined, topLevelOpts }
+    return {
+      type: 'help',
+      targetSubcommand: undefined,
+      topLevelOptions: topLevelOpts
+    }
   }
 
   const [subcommandName, subcommand, defaultSubcommandUsed] = selectSubcommand(
@@ -45,7 +49,11 @@ export function parse<T extends TopLevelOptions>(
 
   const args = !defaultSubcommandUsed ? input.slice(1) : input
   if (args[0] === HELP_FLAG) {
-    return { type: 'help', targetSubcommand: subcommandName, topLevelOpts }
+    return {
+      type: 'help',
+      targetSubcommand: subcommandName,
+      topLevelOptions: topLevelOpts
+    }
   }
 
   const mergedArguments = {

--- a/packages/ordana/src/types.ts
+++ b/packages/ordana/src/types.ts
@@ -164,6 +164,7 @@ export type NormalParsedResults<T extends TopLevelOptions> =
 type SpecialParsedResults = {
   type: 'help'
   targetSubcommand: string | undefined
+  topLevelOpts: TopLevelOptions
 }
 
 export type ParsedResults<T extends TopLevelOptions> =

--- a/packages/ordana/src/types.ts
+++ b/packages/ordana/src/types.ts
@@ -164,7 +164,7 @@ export type NormalParsedResults<T extends TopLevelOptions> =
 type SpecialParsedResults = {
   type: 'help'
   targetSubcommand: string | undefined
-  topLevelOpts: TopLevelOptions
+  topLevelOptions: TopLevelOptions
 }
 
 export type ParsedResults<T extends TopLevelOptions> =


### PR DESCRIPTION
This will make generating the help message easier, as I won't be required to store the top-level options in a variable if I prefer not to.

```ts
const result = parse(['dev', '--help'], { … })
if (result.type === 'help') {
  console.log(generateHelpMessage(result))
  process.exit()
}
```
