### PR TITLE
fix: import picocolors without namespace

### DIFF
--- a/.changeset/five-dryers-tie.md
+++ b/.changeset/five-dryers-tie.md
@@ -1,0 +1,5 @@
+---
+"ordana": patch
+---
+
+Fix error `c.blue is not a function` from happening.

--- a/packages/ordana/src/help.ts
+++ b/packages/ordana/src/help.ts
@@ -6,7 +6,7 @@ import {
   stringifyArgumentType,
   stringifyPositionals
 } from './utils.ts'
-import * as c from 'picocolors'
+import c from 'picocolors'
 
 /**
  * Generate help message


### PR DESCRIPTION
I was getting this error when using ordana from a ESM project.

```
TypeError: c.blue is not a function
    at generateUsageSection (file:///path/to/project/node_modules/.pnpm/ordana@0.3.0/node_modules/ordana/dist/index.js:181:21)
```
